### PR TITLE
Fix(cleaning): Cleaning Up Unused Dependencies and Cleaning the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ The download will start automatically after submitting the form.
 
 ## Project structure
 
-- `/pages`: Contains the Next.js pages.
+- `/app`: Contains the Next.js pages and API routes (App Router).
 
-- `index.js`: Home page with the download form.
+- `page.js`: Home page with the download form.
 
-- `api`: Folder containing the API to manage download requests.
+- `/api` : Folder containing the API (`route.js`) to manage download requests.
 
 - `/public` : Contains static files (images, styles, etc.).
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "deepseek": "file:",
     "next": "15.1.6",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "ytdl-core": "^4.11.5"
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "postcss": "^8",


### PR DESCRIPTION
## Problems: 
- The package.json file contains dependencies that aren't used by the project, which makes the installation heavier.
- The README.md describes an architecture that doesn't match the code. It says the project uses the /pages folder and index.js, but the project actually uses the Next.js App Router with the /app folder.

## Solutions:
- I removed these dependencies.
- I updated the 'Project structure' section to reflect the use of the App Router.